### PR TITLE
Integerwerte bis 64Bit vorzeichenbehaftet, neuer Zähler MT691, Bugfix EMH ED300L, Bugfix refTime

### DIFF
--- a/templates/multi/main.html
+++ b/templates/multi/main.html
@@ -191,7 +191,7 @@
 	<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 	<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
 	<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
-	<option value="iskra682sml">Iskra MT691 (SML-Protocol)</option>
+	<option value="iskra691sml">Iskra MT691 (SML-Protocol)</option>
 	<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
 	<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 	<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>
@@ -316,7 +316,7 @@
 		<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 		<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
 		<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
-		<option value="iskra682sml">Iskra MT691 (SML-Protocol)</option>
+		<option value="iskra691sml">Iskra MT691 (SML-Protocol)</option>
 		<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
 		<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 		<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>

--- a/templates/multi/main.html
+++ b/templates/multi/main.html
@@ -191,7 +191,7 @@
 	<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 	<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
 	<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
-	<option value="iskra682sml">Iskra MT682 (SML-Protocol)</option>
+	<option value="iskra682sml">Iskra MT691 (SML-Protocol)</option>
 	<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
 	<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 	<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>
@@ -316,7 +316,7 @@
 		<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 		<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
 		<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
-		<option value="iskra682sml">Iskra MT682 (SML-Protocol)</option>
+		<option value="iskra682sml">Iskra MT691 (SML-Protocol)</option>
 		<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
 		<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 		<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>

--- a/templates/multi/main.html
+++ b/templates/multi/main.html
@@ -190,6 +190,7 @@
 	<option value="iskra174sml">Iskra MT174 (SML-Protocol)</option>
 	<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 	<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
+	<option value="iskra382d0">Iskra MT382 (D0-Protocol)</option>
 	<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
 	<option value="iskra691sml">Iskra MT691 (SML-Protocol)</option>
 	<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
@@ -315,6 +316,7 @@
 		<option value="iskra174sml">Iskra MT174 (SML-Protocol)</option>
 		<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 		<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
+		<option value="iskra382d0">Iskra MT382 (D0-Protocol)</option>
 		<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
 		<option value="iskra691sml">Iskra MT691 (SML-Protocol)</option>
 		<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>

--- a/templates/multi/main.html
+++ b/templates/multi/main.html
@@ -191,6 +191,7 @@
 	<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 	<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
 	<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
+	<option value="iskra682sml">Iskra MT682 (SML-Protocol)</option>
 	<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
 	<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 	<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>
@@ -315,6 +316,7 @@
 		<option value="iskra175d0">Iskra MT175 (D0-Protocol)</option>
 		<option value="iskra175sml">Iskra MT175 (SML-Protocol)</option>
 		<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
+		<option value="iskra682sml">Iskra MT682 (SML-Protocol)</option>
 		<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
 		<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 		<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>

--- a/webfrontend/cgi/bin/php_sml_parser.class.php
+++ b/webfrontend/cgi/bin/php_sml_parser.class.php
@@ -259,6 +259,27 @@ class SML_PARSER {
         if($val & 0x80) $val = 0xfe - $val;
         return $val;
     }
+	private function readSmlTime() {
+        $TYPE_LEN = $this->read(1);
+	    if($TYPE_LEN=='01') return; # SML Time optional
+	
+		if($TYPE_LEN=='72') {
+			$result['choice']  = $this->readUnsigned($this->data);
+			switch($result['choice']) {
+				case '01': # secIndex
+					$sml_time = $this->readUnsigned($this->data);
+					break;
+				case '02': # timestamp
+					$sml_time = $this->readUnsigned($this->data);
+					break;
+				default:
+					$this->debug('SML_Time UnknownRequest ('.$result['choice'].')');
+			} 	
+        }else{
+            return "[Error, cant read SML_Time]";
+        }
+		return $sml_time;
+    }
     # =============================================================================================
     # High-Level SML-Funktionen
     # =============================================================================================
@@ -268,8 +289,8 @@ class SML_PARSER {
         $result['clientId']    = $this->readOctet($this->data);
         $result['reqFileId']   = $this->readOctet($this->data);
         $result['serverId']    = $this->readOctet($this->data);
-        $result['refTime']     = $this->readOctet($this->data);
-        $result['sml-Version'] = $this->readOctet($this->data);
+        $result['refTime']     = $this->readSmlTime();
+        $result['sml-Version'] = $this->readUnsigned($this->data);
         return $result;
     }
     private function readCloseResponse() {

--- a/webfrontend/cgi/bin/php_sml_parser.class.php
+++ b/webfrontend/cgi/bin/php_sml_parser.class.php
@@ -18,7 +18,7 @@ class SML_PARSER {
         '0100000009FF' => array('1-0:0.0.9*255',' Geraeteeinzelidentifikation'),
         '00006001FFFF' => array('0-0:60.1.255*255','Fabriknummer'),
         '0100100700FF' => array('1-0:16.7.0*255','aktuelle Gesamtwirkleistung'),
-		'0100020800FF' => array('1-0:2.8.0*255','Wirkarbeit Lieferung Total: Zaehlerstand')
+	'0100020800FF' => array('1-0:2.8.0*255','Wirkarbeit Lieferung Total: Zaehlerstand')
     );
 	
     private $data;

--- a/webfrontend/cgi/bin/php_sml_parser.class.php
+++ b/webfrontend/cgi/bin/php_sml_parser.class.php
@@ -142,7 +142,7 @@ class SML_PARSER {
                 #return $this->hex2bin($this->read($LEN-1));
                 return $this->read($LEN-1);
                 break;
-			case '5x': # Integer
+			case '5x': #  Integer
 				if ($LEN==2) {
 					# 8 Bit signed Integer
 					$temp = hexdec($this->read($LEN-1));

--- a/webfrontend/cgi/bin/php_sml_parser.class.php
+++ b/webfrontend/cgi/bin/php_sml_parser.class.php
@@ -17,8 +17,10 @@ class SML_PARSER {
         '0100010800FF' => array('1-0:1.8.0*255','Wirkarbeit Bezug Total: Zaehlerstand'),
         '0100000009FF' => array('1-0:0.0.9*255',' Geraeteeinzelidentifikation'),
         '00006001FFFF' => array('0-0:60.1.255*255','Fabriknummer'),
-        '0100100700FF' => array('1-0:16.7.0*255','aktuelle Gesamtwirkleistung')
+        '0100100700FF' => array('1-0:16.7.0*255','aktuelle Gesamtwirkleistung'),
+		'0100020800FF' => array('1-0:2.8.0*255','Wirkarbeit Lieferung Total: Zaehlerstand')
     );
+	
     private $data;
     private $crc16_global;
     private $crc16_message;
@@ -144,56 +146,63 @@ class SML_PARSER {
 				if ($LEN==2) {
 					# 8 Bit signed Integer
 					$temp = hexdec($this->read($LEN-1));
-					$this->debug('Value: ('.$temp.')');
 					if($temp & 0x80) {
 						# negativer Wert, Umrechnung 2er Komplement	
 						$temp -= pow(2,8); # 256
-						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						$this->debug('signed Integer: ('.$temp.')');
 						return $temp;
 					}
 					else{
+						$this->debug('Integer: ('.$temp.')');
 						return $temp;
 					}
 				}
 				if ($LEN==3) {
 					# 16 Bit signed Integer
 					$temp = hexdec($this->read($LEN-1));
-					$this->debug('Value Rohwert: ('.$temp.')');
 					if($temp & 0x8000) {
 						# negativer Wert, Umrechnung 2er Komplement	
 						$temp -= pow(2,16); # 65536
-						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						$this->debug('signed Integer: ('.$temp.')');
 						return $temp;
 					}
 					else{
+						$this->debug('Integer: ('.$temp.')');
 						return $temp;
 					}
 				}
 				if ($LEN==5) {
 					# 32 Bit signed Integer
 					$temp = hexdec($this->read($LEN-1));
-					$this->debug('Value Rohwert: ('.$temp.')');
 					if($temp & 0x80000000) {
 						# negativer Wert, Umrechnung 2er Komplement	
 						$temp -= pow(2,32); # 4294967296
-						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						$this->debug('signed Integer: ('.$temp.')');
 						return $temp;
 					}
 					else{
+						$this->debug('Integer: ('.$temp.')');
 						return $temp;
 					}
+				}
+				if ($LEN==6) {
+					# Eigenheit von EMH ED300L Zähler
+					# Überträgt positive Zahlen sporadisch mit Längenangabe 6 im Telegramm
+					$temp = hexdec($this->read($LEN-1));
+					$this->debug('Integer: ('.$temp.')');
+					return $temp;
 				}
 				if ($LEN==9) {
 					# 64 Bit signed Integer
 					$temp = hexdec($this->read($LEN-1));
-					$this->debug('Value Rohwert: ('.$temp.')');
 					if($temp & 0x8000000000000000) {
 						# negativer Wert, Umrechnung 2er Komplement	
 						$temp -= pow(2,64); # 18446744073709551616
-						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						$this->debug('signed Integer: ('.$temp.')');
 						return $temp;
 					}
 					else{
+						$this->debug('Integer: ('.$temp.')');
 						return $temp;
 					}
 				}

--- a/webfrontend/cgi/bin/php_sml_parser.class.php
+++ b/webfrontend/cgi/bin/php_sml_parser.class.php
@@ -140,9 +140,64 @@ class SML_PARSER {
                 #return $this->hex2bin($this->read($LEN-1));
                 return $this->read($LEN-1);
                 break;
-            case '5x': # Integer
-                return hexdec($this->read($LEN-1));
-                break;
+			case '5x': # Integer
+				if ($LEN==2) {
+					# 8 Bit signed Integer
+					$temp = hexdec($this->read($LEN-1));
+					$this->debug('Value: ('.$temp.')');
+					if($temp & 0x80) {
+						# negativer Wert, Umrechnung 2er Komplement	
+						$temp -= pow(2,8); # 256
+						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						return $temp;
+					}
+					else{
+						return $temp;
+					}
+				}
+				if ($LEN==3) {
+					# 16 Bit signed Integer
+					$temp = hexdec($this->read($LEN-1));
+					$this->debug('Value Rohwert: ('.$temp.')');
+					if($temp & 0x8000) {
+						# negativer Wert, Umrechnung 2er Komplement	
+						$temp -= pow(2,16); # 65536
+						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						return $temp;
+					}
+					else{
+						return $temp;
+					}
+				}
+				if ($LEN==5) {
+					# 32 Bit signed Integer
+					$temp = hexdec($this->read($LEN-1));
+					$this->debug('Value Rohwert: ('.$temp.')');
+					if($temp & 0x80000000) {
+						# negativer Wert, Umrechnung 2er Komplement	
+						$temp -= pow(2,32); # 4294967296
+						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						return $temp;
+					}
+					else{
+						return $temp;
+					}
+				}
+				if ($LEN==9) {
+					# 64 Bit signed Integer
+					$temp = hexdec($this->read($LEN-1));
+					$this->debug('Value Rohwert: ('.$temp.')');
+					if($temp & 0x8000000000000000) {
+						# negativer Wert, Umrechnung 2er Komplement	
+						$temp -= pow(2,64); # 18446744073709551616
+						# $this->debug('Value mit Vorzeichenbetrachtung: ('.$temp.')');
+						return $temp;
+					}
+					else{
+						return $temp;
+					}
+				}
+				break;
             case '6x': # UnsignedInt
                 return hexdec($this->read($LEN-1));
                 break;

--- a/webfrontend/cgi/bin/php_sml_parser.class.php
+++ b/webfrontend/cgi/bin/php_sml_parser.class.php
@@ -142,7 +142,7 @@ class SML_PARSER {
                 #return $this->hex2bin($this->read($LEN-1));
                 return $this->read($LEN-1);
                 break;
-			case '5x': #  Integer
+			case '5x': # Integer
 				if ($LEN==2) {
 					# 8 Bit signed Integer
 					$temp = hexdec($this->read($LEN-1));

--- a/webfrontend/cgi/bin/sm_logger.pl
+++ b/webfrontend/cgi/bin/sm_logger.pl
@@ -314,7 +314,7 @@ elsif ( $protocol eq "iskra681sml" ) {
 	&PROTO_GENERICSML;
 }
 
-elsif ( $protocol eq "iskra682sml" ) {
+elsif ( $protocol eq "iskra691sml" ) {
 
 	### Defaults
 	our $baudrate = 9600 if !$baudrate;

--- a/webfrontend/cgi/bin/sm_logger.pl
+++ b/webfrontend/cgi/bin/sm_logger.pl
@@ -314,6 +314,24 @@ elsif ( $protocol eq "iskra681sml" ) {
 	&PROTO_GENERICSML;
 }
 
+elsif ( $protocol eq "iskra682sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
 elsif ( $protocol eq "itronace3000type260d0" ) {
 
 	### Defaults

--- a/webfrontend/cgi/bin/sm_logger.pl
+++ b/webfrontend/cgi/bin/sm_logger.pl
@@ -296,6 +296,24 @@ elsif ( $protocol eq "iskra175sml" ) {
 	&PROTO_GENERICSML;
 }
 
+elsif ( $protocol eq "iskra382d0" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 7 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "even" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "10" if !$timeout;
+	our $delay = "2" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICD0;
+}
+
 elsif ( $protocol eq "iskra681sml" ) {
 
 	### Defaults

--- a/webfrontend/cgi/bin/sm_logger.pl
+++ b/webfrontend/cgi/bin/sm_logger.pl
@@ -908,10 +908,10 @@ sub PARSE_DUMP
 		($readingdelT9) = $dumpbuffer =~ /[\n|\r|:]2\.8\.9[\*255|\*00]*\(([\d\.]+)/;
 
 		### Energy consumption: Power  (OBIS mixture - no standard?)
-		($power1) = $dumpbuffer =~ /[\n|\r|:]1\.7\.0[\*255|\*00]*\(([\d\.]+)/;
-		($power2) = $dumpbuffer =~ /[\n|\r|:]2\.7\.0[\*255|\*00]*\(([\d\.]+)/;
-		($power3) = $dumpbuffer =~ /[\n|\r|:]15\.7\.0[\*255|\*00]*\(([\d\.]+)/;
-		($power4) = $dumpbuffer =~ /[\n|\r|:]16\.7\.0[\*255|\*00]*\(([\d\.]+)/;
+		($power1) = $dumpbuffer =~ /[\n|\r|:]1\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
+		($power2) = $dumpbuffer =~ /[\n|\r|:]2\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
+		($power3) = $dumpbuffer =~ /[\n|\r|:]15\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
+		($power4) = $dumpbuffer =~ /[\n|\r|:]16\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
 
 	}
 

--- a/webfrontend/cgi/bin/sml_parser.php
+++ b/webfrontend/cgi/bin/sml_parser.php
@@ -49,7 +49,9 @@ foreach ($record['body']['vallist'] as $values)
 		{
 			if ( $values['unit'] == "Wh" ) {
 				echo $values['OBIS'] . "(" . ($values['value'] * $values['scaler'] / 1000) . "*" . "kWh)\n";
-			} elseif ( $values['unit'] == "W" ) {
+			} elseif (($values['unit'] == "W") && ($values['scaler'] <> 0)) {
+				echo $values['OBIS'] . "(" . ($values['value'] * $values['scaler'] / 1000) . "*" . "kW)\n";
+			} elseif (($values['unit'] == "W") && ($values['scaler'] == 0)) {
 				echo $values['OBIS'] . "(" . ($values['value'] / 1000) . "*" . "kW)\n";
 			} else {
 				echo $values['OBIS'] . "(" . $values['value'] . "*" . $values['unit'] .")\n";


### PR DESCRIPTION
Integerwerte werden vorzeichenbehaftet ausgegeben.
5x = vorzeichenbehafteter Integerwert
x2 = 8 Bit
x3 = 16 Bit
x5 = 32 Bit
x9 = 64 Bit