### PR TITLE
[Version1] Spannung Phase 3 auf OBIS 72.7.0 korrigieren; alle Leseköpfe in der Protokollansicht listen

### DIFF
--- a/bin/php_sml_parser.class.php
+++ b/bin/php_sml_parser.class.php
@@ -5,7 +5,7 @@ class SML_PARSER {
 		'0100000000FF' => array('1-0:0.0.0*255','Seriennummer'),
 		'0100200700FF' => array('1-0:32.7.0*255','Spannung Phase 1'),
 		'0100340700FF' => array('1-0:52.7.0*255','Spannung Phase 2'),
-		'0100480700FF' => array('1-0:32.7.0*255','Spannung Phase 3'),
+		'0100480700FF' => array('1-0:72.7.0*255','Spannung Phase 3'),
 		'01001F0700FF' => array('1-0:31.7.0*255','Strom Phase 1'),
 		'0100330700FF' => array('1-0:51.7.0*255','Strom Phase 2'),
 		'0100470700FF' => array('1-0:71.7.0*255','Strom Phase 3'),

--- a/webfrontend/htmlauth/logfiles.cgi
+++ b/webfrontend/htmlauth/logfiles.cgi
@@ -97,13 +97,11 @@ opendir(DIR,"/var/run/shm/$psubfolder");
 	@files = readdir(DIR);
 close DIR;
 # Read all devices
-my @devices = split(/\n/,`ls /dev/serial/by-id/usb-Silicon_Labs_CP2104_USB_to_UART_Bridge_Controller_*`);
+my @devices = split(/\n/,`ls /dev/serial/smartmeter/ 2>/dev/null`);
 foreach (@devices)
 {
 	my $device 	= $_;
 	$device 	=~ s/([\n])//g;
-	$device		=~ s%/dev/serial/by-id/usb-Silicon_Labs_CP2104_USB_to_UART_Bridge_Controller_%%g;
-	$device		=~ s%-if00-port0%%g;
 	push (@heads, $device);
 }
 


### PR DESCRIPTION
Fixes #34

Zwei kleine Korrekturen am Legacy-Reader, Ziel ist der `Version1`-Branch. Der Diff sind vier Zeilen in zwei Dateien.

## `bin/php_sml_parser.class.php`

Die OBIS-Kennzahl für die Spannung der dritten Phase (`0100480700FF`) war auf `1-0:32.7.0*255` abgebildet — dieselbe Kennzahl wie Phase 1. `sm_logger.pl` sucht in Zeile 991 nach `72.7.0` und fand deshalb nie einen Wert; `Instantaneous_Voltage_L3_72.7.0` blieb bei SML-Zählern immer leer.

Geändert: eine Zeile, `32` → `72`.

## `webfrontend/htmlauth/logfiles.cgi`

Die Geräteliste suchte fest nach `usb-Silicon_Labs_CP2104_USB_to_UART_Bridge_Controller_*`. Wer einen FTDI-, CP2102- oder Prolific-Lesekopf benutzt, konnte den Zähler zwar konfigurieren und auslesen, sah in der Protokollansicht aber keine Geräte.

Jetzt wird `/dev/serial/smartmeter/` gelesen — das Verzeichnis, das `daemon/daemon` per udev-Regel ohnehin für jedes ttyUSB-Gerät füllt. Dort stehen bereits die reinen Seriennummern, deshalb entfallen die beiden nachgelagerten Ersetzungen. Damit stimmt die Liste zugleich mit der Namensform überein, die der Rest des Plugins verwendet.

Geändert: eine Zeile, zwei entfernt.

---

Beide Dateien sind unverändert LF und wurden hochgeladen, nicht im Web-Editor bearbeitet — an Einrückung und Zeilenenden ist nichts angefasst.