### PR TITLE
[Version1] 19 Zählerprofile aus dem Forumsthread ergänzen; Delay 0s; D0-Kennziffern ohne dritte Stelle

### DIFF
--- a/bin/sm_logger.pl
+++ b/bin/sm_logger.pl
@@ -502,6 +502,361 @@ elsif ( $protocol eq "sagemcomt211d0f" ) {
 	&PROTO_GENERICD0("FLANDERS");
 }
 
+elsif ( $protocol eq "apatornorax3dsml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "apatorpicusehz060sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "0" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "bauerbsmqd36ad0" ) {
+
+	### Defaults
+	our $baudrate = 300 if !$baudrate;
+	our $startbaudrate = 300 if !$startbaudrate;
+	our $databits = 7 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "even" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "30" if !$timeout;
+	our $delay = "2" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICD0;
+}
+
+elsif ( $protocol eq "dzgdvs7410sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "60" if !$timeout;
+	our $delay = "2" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "dzgdvs7420sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "30" if !$timeout;
+	our $delay = "2" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "easymeteresy5q3dad0" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 7 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "even" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "2" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICD0;
+}
+
+elsif ( $protocol eq "easymeterq3asml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "efrsgmc2sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "efrsgmc4sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "efrsgmddsml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "30" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "elsteras3000d0" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 300 if !$startbaudrate;
+	our $databits = 7 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "even" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "13" if !$timeout;
+	our $delay = "2" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICD0;
+}
+
+elsif ( $protocol eq "hagerehz363sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "holleydtz541sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "landisgyre220sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "logarexlk13bdd0" ) {
+
+	### Defaults
+	our $baudrate = 4800 if !$baudrate;
+	our $startbaudrate = 300 if !$startbaudrate;
+	our $databits = 7 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "even" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "2" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICD0;
+}
+
+elsif ( $protocol eq "logarexlk13be8030d0" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 7 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "even" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "4" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICD0;
+}
+
+elsif ( $protocol eq "sagemcomsmartybzsml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
+elsif ( $protocol eq "sagemcomt210d0" ) {
+
+	### Defaults
+	our $baudrate = 115200 if !$baudrate;
+	our $startbaudrate = 115200 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "20" if !$timeout;
+	our $delay = "5" if !$delay;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICD0;
+}
+
+elsif ( $protocol eq "zpagh305sml" ) {
+
+	### Defaults
+	our $baudrate = 9600 if !$baudrate;
+	our $startbaudrate = 9600 if !$startbaudrate;
+	our $databits = 8 if !$databits;
+	our $stopbits = 1 if !$stopbits;
+	our $parity = "none" if !$parity;
+	our $handshake = "none" if !$handshake;
+	our $timeout = "5" if !$timeout;
+	our $delay = "1" if !$delay;
+	our $crc = "CRC16_X_25" if !$crc;
+	our $preinitcommand = "";
+	our $precommand = "";
+	our $postcommand = "";
+
+	&PROTO_GENERICSML;
+}
+
 else {
 	$verbose =1;
 	&LOG ("No known protocol specified. Try --help to get an overview of possible options.", "FAIL");
@@ -977,21 +1332,21 @@ sub PARSE_DUMP
 		($readingdelT9) = $dumpbuffer =~ /[\n|\r|:]2\.8\.9[\*255|\*00]*\(([\d\.]+)/;
 
 		### Energy consumption: Power  (OBIS mixture - no standard?)
-		($power1) = $dumpbuffer =~ /[\n|\r|:]1\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($power2) = $dumpbuffer =~ /[\n|\r|:]2\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($power3) = $dumpbuffer =~ /[\n|\r|:]15\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($power4) = $dumpbuffer =~ /[\n|\r|:]16\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($power5) = $dumpbuffer =~ /[\n|\r|:]21\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($power6) = $dumpbuffer =~ /[\n|\r|:]41\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($power7) = $dumpbuffer =~ /[\n|\r|:]61\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
+		($power1) = $dumpbuffer =~ /[\n|\r|:]1\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($power2) = $dumpbuffer =~ /[\n|\r|:]2\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($power3) = $dumpbuffer =~ /[\n|\r|:]15\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($power4) = $dumpbuffer =~ /[\n|\r|:]16\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($power5) = $dumpbuffer =~ /[\n|\r|:]21\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($power6) = $dumpbuffer =~ /[\n|\r|:]41\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($power7) = $dumpbuffer =~ /[\n|\r|:]61\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
 
 		### Instantaneous voltage
-		($volt1) = $dumpbuffer =~ /[\n|\r|:]32\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($volt2) = $dumpbuffer =~ /[\n|\r|:]52\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($volt3) = $dumpbuffer =~ /[\n|\r|:]72\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($current1) = $dumpbuffer =~ /[\n|\r|:]31\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($current2) = $dumpbuffer =~ /[\n|\r|:]51\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
-		($current3) = $dumpbuffer =~ /[\n|\r|:]71\.7\.0[\*255|\*00]*\(([-\d\.]+)/;
+		($volt1) = $dumpbuffer =~ /[\n|\r|:]32\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($volt2) = $dumpbuffer =~ /[\n|\r|:]52\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($volt3) = $dumpbuffer =~ /[\n|\r|:]72\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($current1) = $dumpbuffer =~ /[\n|\r|:]31\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($current2) = $dumpbuffer =~ /[\n|\r|:]51\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
+		($current3) = $dumpbuffer =~ /[\n|\r|:]71\.7(?:\.0)?[\*255|\*00]*\(([-\d\.]+)/;
 		
 		### Equipment Data
 		($eid) = $dumpbuffer =~ /[\n|\r|:]96\.1\.1[\*255|\*00]*\(([-\d\.]+)/;

--- a/templates/multi/main.html
+++ b/templates/multi/main.html
@@ -205,9 +205,22 @@
 	<option value="manual"><TMPL_VAR NAME=T::FORMTABLEROWS.MANUAL></option>
 	<option value="genericd0">Generic D0-Protocol</option>
 	<option value="genericsml">Generic SML-Protocol</option>
+	<option value="apatornorax3dsml">Apator Norax 3D (SML-Protocol)</option>
+	<option value="apatorpicusehz060sml">Apator Picus eHZ.060.D (SML-Protocol)</option>
+	<option value="bauerbsmqd36ad0">Bauer BSM-QD36A (D0-Protocol)</option>
+	<option value="dzgdvs7410sml">DZG DVS7410 (SML-Protocol)</option>
+	<option value="dzgdvs7420sml">DZG DVS7420.1 (SML-Protocol)</option>
+	<option value="easymeteresy5q3dad0">Easymeter ESY5Q3DA (D0-Protocol)</option>
+	<option value="easymeterq3asml">Easymeter Q3A (SML-Protocol)</option>
+	<option value="efrsgmc2sml">EFR SGM-C2 (SML-Protocol)</option>
+	<option value="efrsgmc4sml">EFR SGM-C4 (SML-Protocol)</option>
+	<option value="efrsgmddsml">EFR SGM-DD / Digimeto (SML-Protocol)</option>
+	<option value="elsteras3000d0">Elster AS3000 (D0-Protocol)</option>
 	<option value="emhed300sml">EMH ED300(S) (SML-Protocol)</option>
 	<option value="emhehzksml">EMH eHZ-K (SML-Protocol)</option>
 	<option value="emhehzksml">EMH eHZ-IW8E2A (SML-Protocol)</option>
+	<option value="hagerehz363sml">Hager eHZ363 (SML-Protocol)</option>
+	<option value="holleydtz541sml">Holley DTS541/DTZ541 (SML-Protocol)</option>
 	<option value="iskra173d0">Iskra MT173 (D0-Protocol)</option>
 	<option value="iskra173sml">Iskra MT173 (SML-Protocol)</option>
 	<option value="iskra174d0">Iskra MT174 (D0-Protocol)</option>
@@ -218,14 +231,20 @@
 	<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
 	<option value="iskra691sml">Iskra MT691 (SML-Protocol)</option>
 	<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
+	<option value="landisgyre220sml">Landis &amp; Gyre E220 (SML-Protocol)</option>
 	<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 	<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>
 	<option value="landisgyret550d0">Landis &amp; Gyre T550 (D0-Protocol)</option>
+	<option value="logarexlk13bdd0">Logarex LK13BD (D0-Protocol)</option>
+	<option value="logarexlk13be8030d0">Logarex LK13BE8030x9 (D0-Protocol)</option>
 	<option value="pafal20ec3grd0">Pafal 20ec3gr (D0-Protocol)</option>
 	<option value="siemenstd3511d0">Siemens TD-3511 (D0-Protocol)</option>
 	<option value="siemensuh50do">Siemens UH50 (D0-Protocol)</option>
 	<option value="sagemcomt211d0f">Sagemcom S211/T211 Flanders(D0-Protocol)</option>
 	<option value="sagemcomt211d0">Sagemcom S211/T211 (D0-Protocol)</option>
+	<option value="sagemcomsmartybzsml">Sagemcom SMARTY BZ-PLUS (SML-Protocol)</option>
+	<option value="sagemcomt210d0">Sagemcom T210-D (D0-Protocol)</option>
+	<option value="zpagh305sml">ZPA GH305 (SML-Protocol)</option>
 	</select>
 	<script>
 	// Select option depending on saved config
@@ -341,9 +360,22 @@
 		<select id="<TMPL_VAR NAME=SERIAL>_protocol" name="<TMPL_VAR NAME=SERIAL>_protocol" data-mini="true" data-native-menu="true">
 		<option value="genericd0">Generic D0-Protocol</option>
 		<option value="genericsml">Generic SML-Protocol</option>
+		<option value="apatornorax3dsml">Apator Norax 3D (SML-Protocol)</option>
+		<option value="apatorpicusehz060sml">Apator Picus eHZ.060.D (SML-Protocol)</option>
+		<option value="bauerbsmqd36ad0">Bauer BSM-QD36A (D0-Protocol)</option>
+		<option value="dzgdvs7410sml">DZG DVS7410 (SML-Protocol)</option>
+		<option value="dzgdvs7420sml">DZG DVS7420.1 (SML-Protocol)</option>
+		<option value="easymeteresy5q3dad0">Easymeter ESY5Q3DA (D0-Protocol)</option>
+		<option value="easymeterq3asml">Easymeter Q3A (SML-Protocol)</option>
+		<option value="efrsgmc2sml">EFR SGM-C2 (SML-Protocol)</option>
+		<option value="efrsgmc4sml">EFR SGM-C4 (SML-Protocol)</option>
+		<option value="efrsgmddsml">EFR SGM-DD / Digimeto (SML-Protocol)</option>
+		<option value="elsteras3000d0">Elster AS3000 (D0-Protocol)</option>
 		<option value="emhed300sml">EMH ED300(S) (SML-Protocol)</option>
 		<option value="emhehzksml">EMH eHZ-K (SML-Protocol)</option>
 		<option value="emhehzksml">EMH eHZ-IW8E2A (SML-Protocol)</option>
+		<option value="hagerehz363sml">Hager eHZ363 (SML-Protocol)</option>
+		<option value="holleydtz541sml">Holley DTS541/DTZ541 (SML-Protocol)</option>
 		<option value="iskra173d0">Iskra MT173 (D0-Protocol)</option>
 		<option value="iskra173sml">Iskra MT173 (SML-Protocol)</option>
 		<option value="iskra174d0">Iskra MT174 (D0-Protocol)</option>
@@ -354,14 +386,20 @@
 		<option value="iskra681sml">Iskra MT681 (SML-Protocol)</option>
 		<option value="iskra691sml">Iskra MT691 (SML-Protocol)</option>
 		<option value="itronace3000type260d0">Itron ACE3000 Type 260 (D0-Protocol)</option>
+		<option value="landisgyre220sml">Landis &amp; Gyre E220 (SML-Protocol)</option>
 		<option value="landisgyre320d0">Landis &amp; Gyre E320 (D0-Protocol)</option>
 		<option value="landisgyre350d0">Landis &amp; Gyre E350 (D0-Protocol)</option>
 		<option value="landisgyret550d0">Landis &amp; Gyre T550 (D0-Protocol)</option>
+		<option value="logarexlk13bdd0">Logarex LK13BD (D0-Protocol)</option>
+		<option value="logarexlk13be8030d0">Logarex LK13BE8030x9 (D0-Protocol)</option>
 		<option value="pafal20ec3grd0">Pafal 20ec3gr (D0-Protocol)</option>
 		<option value="siemenstd3511d0">Siemens TD-3511 (D0-Protocol)</option>
 		<option value="siemensuh50do">Siemens UH50 (D0-Protocol)</option>
 		<option value="sagemcomt211d0f">Sagemcom S211/T211 Flanders(D0-Protocol)</option>
 		<option value="sagemcomt211d0">Sagemcom S211/T211 (D0-Protocol)</option>
+		<option value="sagemcomsmartybzsml">Sagemcom SMARTY BZ-PLUS (SML-Protocol)</option>
+		<option value="sagemcomt210d0">Sagemcom T210-D (D0-Protocol)</option>
+		<option value="zpagh305sml">ZPA GH305 (SML-Protocol)</option>
 		</select>
 		<script>
 		// Select option depending on saved config
@@ -489,6 +527,7 @@
 		<label id="label<TMPL_VAR NAME=SERIAL>_delay"><TMPL_VAR NAME=T::FORMTABLEROWS.DELAY></label>
 		<td>
 		<select id="<TMPL_VAR NAME=SERIAL>_delay" name="<TMPL_VAR NAME=SERIAL>_delay" data-mini="true" data-native-menu="true">
+		<option value="0">0s</option>
 		<option value="1">1s</option>
 		<option value="2">2s</option>
 		<option value="3">3s</option>


### PR DESCRIPTION
Fixes #36

Ziel ist der `Version1`-Branch. Rein additiv bis auf dreizehn geänderte Zeilen in `sm_logger.pl`.

## Neue Zählerprofile

19 Profile, deren Parameter im Forumsthread vollständig dokumentiert sind, die aber nie ins Auswahlmenü kamen. Die vollständige Tabelle mit Fundstellen steht in #36.

Apator Norax 3D, Apator Picus eHZ.060.D, Bauer BSM-QD36A, DZG DVS7410, DZG DVS7420.1, Easymeter ESY5Q3DA, Easymeter Q3A, EFR SGM-C2, EFR SGM-C4, EFR SGM-DD (Digimeto), Elster AS3000, Hager eHZ363, Holley DTS541/DTZ541, Landis & Gyr E220, Logarex LK13BD, Logarex LK13BE8030x9, Sagemcom SMARTY BZ-PLUS, Sagemcom T210-D, ZPA GH305

Jeder Block folgt dem Muster der vorhandenen Profile und ruft `PROTO_GENERICSML` beziehungsweise `PROTO_GENERICD0` auf — kein neuer Code, nur Voreinstellungen. SML-Profile bekommen `CRC16_X_25`.

## Delay 0s

`templates/multi/main.html` bot als kleinsten Wert 1 s an. Der Apator Picus wird mit 0 betrieben; der Nutzer hatte in #708 angemerkt, dass man einen einmal gewählten Wert nicht mehr loswird. Eine Zeile.

## D0-Kennziffern ohne dritte Stelle

Im D0-Zweig von `sm_logger.pl` waren die Kennziffern fest als `32\.7\.0` geschrieben. Zähler wie der Landis & Gyr E350 senden `32.7(232*V)` ohne dritte Stelle, die Werte gingen verloren. Dreizehn Muster lauten jetzt `32\.7(?:\.0)?` — dieselbe Schreibweise wie im SML-Zweig.

Gegen echte Datensätze aus dem Thread geprüft:

| Datensatz | vorher | nachher |
|---|---|---|
| L&G E350, `32.7(232*V)` | kein Wert | 232 |
| Bauer BSM, `1-0:32.7.0(236.0*V)` | 236.0 | 236.0 |
| negativ, `1-0:15.7.0(-00000.315*kW)` | -00000.315 | -00000.315 |

Keine Fehltreffer: `1.7` zieht nichts aus `21.7.0`, `31.7.0`, `51.7.0` oder `71.7.0`, weil das führende Trennzeichen im Muster steht.

## Prüfungen

`perl -c` läuft durch. Jeder Menüwert hat genau einen Zweig in `sm_logger.pl` und umgekehrt. Beide Dateien sind unverändert LF und wurden hochgeladen statt im Web-Editor bearbeitet.

Wenn dir einzelne Profile zu wenig belegt sind, nehme ich sie gern wieder heraus.